### PR TITLE
8 fix broken nav on deployed site

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const isProd = process.env.NODE_ENV === 'production'
 const nextConfig = {
   reactStrictMode: true,
   assetPrefix: isProd ? '/me/' : '',
-  basePath: isProd ? '/me/' : '',
+  basePath: isProd ? '/me' : '',
 }
 
 module.exports = nextConfig

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,8 @@ const isProd = process.env.NODE_ENV === 'production'
 
 const nextConfig = {
   reactStrictMode: true,
-  assetPrefix: isProd ? '/me/' : ''
+  assetPrefix: isProd ? '/me/' : '',
+  basePath: isProd ? '/me/' : '',
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
CI build in last integrate failed with this error

```
> me@0.1.0 build
> next build


> Build error occurred
Error: Specified basePath should not end with /, found "/me/"
    at assignDefaults (/home/runner/work/me/me/node_modules/next/dist/server/config.js:1[7]
```

So removing the extra `/` and created a tracker item https://github.com/jarekb84/me/issues/1 to add a build step as an integrate check